### PR TITLE
Make sure CanDispel isn't nil.

### DIFF
--- a/embeds/oUF_DebuffHighlight/oUF_DebuffHighlight.lua
+++ b/embeds/oUF_DebuffHighlight/oUF_DebuffHighlight.lua
@@ -13,7 +13,7 @@ local DISPELTYPES = {
 	MAGE = {Curse = false},
 }
 
-local CanDispel = DISPELTYPES[PlayerClass]
+local CanDispel = DISPELTYPES[PlayerClass] or {}
 local OriginalColors = {}
 local DebuffTypeColor = DebuffTypeColor
 


### PR DESCRIPTION
CanDispel will be `nil` for classes not in the `DISPELTYPES` table. And throw a `bad argument #1 to 'pairs' (table expected, got nil)` error on [line 39 in oUF_DebuffHighlight.lua](https://github.com/ls-/oUF_LS/blob/v2/embeds/oUF_DebuffHighlight/oUF_DebuffHighlight.lua#L39-L41).

To reproduce, just play any class not in the `DISPELTYPES` table and engage some mob that buffs itself.